### PR TITLE
tty: samsung: fix permissions for error_cnt node

### DIFF
--- a/drivers/tty/serial/samsung.c
+++ b/drivers/tty/serial/samsung.c
@@ -291,7 +291,7 @@ uart_error_cnt_show(struct device *dev, struct device_attribute *attr, char *buf
 	return ret;
 }
 
-static DEVICE_ATTR(error_cnt, 0664, uart_error_cnt_show, NULL);
+static DEVICE_ATTR(error_cnt, S_IRUGO, uart_error_cnt_show, NULL);
 
 static void s3c24xx_serial_resetport(struct uart_port *port,
 				   struct s3c2410_uartcfg *cfg);


### PR DESCRIPTION
this fix removes the following warning:
<4>[    1.125522]  [7:      swapper/0:    1] ------------[ cut here ]------------
<4>[    1.125547]  [7:      swapper/0:    1] WARNING: at ../../../../../../kernel/samsung/exynos7870/drivers/base/core.c:558 device_create_file+0x9c/0xb4()
<4>[    1.125562]  [7:      swapper/0:    1] Attribute error_cnt: write permission without 'store'
<4>[    1.125576]  [7:      swapper/0:    1] Modules linked in:
<4>[    1.125595]  [7:      swapper/0:    1] CPU: 7 MPIDR: 80000103 PID: 1 Comm: swapper/0 Tainted: G        W      3.18.140-SIMPLE-KERNEL_V1.2 #11
<4>[    1.125610]  [7:      swapper/0:    1] Hardware name: Samsung A3Y17 LTE EUR rev03 board based on Exynos7870 (DT)
<0>[    1.125625]  [7:      swapper/0:    1] Call trace:
<4>[    1.125644]  [7:      swapper/0:    1] [<ffffffc000088ec8>] dump_backtrace+0x0/0x140
<4>[    1.125662]  [7:      swapper/0:    1] [<ffffffc00008901c>] show_stack+0x14/0x1c
<4>[    1.125681]  [7:      swapper/0:    1] [<ffffffc000cd0744>] dump_stack+0x84/0xa8
<4>[    1.125700]  [7:      swapper/0:    1] [<ffffffc00009dc34>] warn_slowpath_fmt+0xb4/0xec
<4>[    1.125718]  [7:      swapper/0:    1] [<ffffffc0004dbb70>] device_create_file+0x9c/0xb4
<4>[    1.125736]  [7:      swapper/0:    1] [<ffffffc00047b9e4>] s3c24xx_serial_probe+0x6bc/0xa6c
<4>[    1.125754]  [7:      swapper/0:    1] [<ffffffc0004e2db4>] platform_drv_probe+0x4c/0xc4
<4>[    1.125772]  [7:      swapper/0:    1] [<ffffffc0004e0db8>] really_probe+0x80/0x224
<4>[    1.125788]  [7:      swapper/0:    1] [<ffffffc0004e116c>] driver_probe_device+0x30/0x58
<4>[    1.125805]  [7:      swapper/0:    1] [<ffffffc0004e1230>] __driver_attach+0x9c/0xa0
<4>[    1.125822]  [7:      swapper/0:    1] [<ffffffc0004deddc>] bus_for_each_dev+0x64/0xb4
<4>[    1.125838]  [7:      swapper/0:    1] [<ffffffc0004e09d4>] driver_attach+0x20/0x28
<4>[    1.125855]  [7:      swapper/0:    1] [<ffffffc0004e060c>] bus_add_driver+0x14c/0x200
<4>[    1.125872]  [7:      swapper/0:    1] [<ffffffc0004e1c60>] driver_register+0x74/0x10c
<4>[    1.125889]  [7:      swapper/0:    1] [<ffffffc0004e2ce8>] __platform_driver_register+0x60/0x68
<4>[    1.125906]  [7:      swapper/0:    1] [<ffffffc001377ad8>] s3c24xx_serial_modinit+0x4c/0x58
<4>[    1.125922]  [7:      swapper/0:    1] [<ffffffc000081a04>] do_one_initcall+0x94/0x1c0
<4>[    1.125941]  [7:      swapper/0:    1] [<ffffffc00134abd0>] kernel_init_freeable+0x140/0x1ec
<4>[    1.125958]  [7:      swapper/0:    1] [<ffffffc000ccd744>] kernel_init+0x10/0x120
<4>[    1.125973]  [7:      swapper/0:    1] ---[ end trace 8d0451c49721b746 ]---